### PR TITLE
add python module

### DIFF
--- a/fullbody_inverse_kinematics_solver/CMakeLists.txt
+++ b/fullbody_inverse_kinematics_solver/CMakeLists.txt
@@ -122,16 +122,16 @@ include_directories(
   ${CHOREONOID_INCLUDE_DIRS}
 )
 
-# 相対パスを絶対パスに直す
-set(CHOREONOID_BODY_LIBRARIES_ABS)
-foreach(lib ${CHOREONOID_BODY_LIBRARIES})
-  find_library(${lib}_abs NAMES ${lib} PATHS ${CHOREONOID_LIBRARY_DIRS})
-  if (NOT (${lib}_abs))
-    set(${lib}_abs ${lib})
-  endif()
-  set(CHOREONOID_BODY_LIBRARIES_ABS ${CHOREONOID_BODY_LIBRARIES_ABS} ${${lib}_abs})
-endforeach(lib)
-message ("cnoid_body_lib: ${CHOREONOID_BODY_LIBRARIES_ABS}")
+### 相対パスを絶対パスに直す
+##set(CHOREONOID_BODY_LIBRARIES_ABS)
+##foreach(lib ${CHOREONOID_BODY_LIBRARIES})
+##  find_library(${lib}_abs NAMES ${lib} PATHS ${CHOREONOID_LIBRARY_DIRS})
+##  if (NOT (${lib}_abs))
+##    set(${lib}_abs ${lib})
+##  endif()
+##  set(CHOREONOID_BODY_LIBRARIES_ABS ${CHOREONOID_BODY_LIBRARIES_ABS} ${${lib}_abs})
+##endforeach(lib)
+##message ("cnoid_body_lib: ${CHOREONOID_BODY_LIBRARIES_ABS}")
 
 add_library(${PROJECT_NAME}
   src/FullbodyInverseKinematicsSolverFast.cpp
@@ -139,19 +139,17 @@ add_library(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
-  ${CHOREONOID_BODY_LIBRARIES_ABS}
+  ${CHOREONOID_BODY_LIBRARIES}
   )
 
 #############
 ## Install ##
 #############
-
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
 )
-
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h"
@@ -160,7 +158,6 @@ install(DIRECTORY include/${PROJECT_NAME}/
 #############
 ## Testing ##
 #############
-
 add_subdirectory(sample)
 add_subdirectory(python)
 

--- a/fullbody_inverse_kinematics_solver/CMakeLists.txt
+++ b/fullbody_inverse_kinematics_solver/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
+cmake_policy(SET CMP0003 NEW)
+cmake_policy(SET CMP0057 NEW)
 project(fullbody_inverse_kinematics_solver)
 
 add_compile_options(-std=c++11)
@@ -124,8 +126,12 @@ include_directories(
 set(CHOREONOID_BODY_LIBRARIES_ABS)
 foreach(lib ${CHOREONOID_BODY_LIBRARIES})
   find_library(${lib}_abs NAMES ${lib} PATHS ${CHOREONOID_LIBRARY_DIRS})
+  if (NOT (${lib}_abs))
+    set(${lib}_abs ${lib})
+  endif()
   set(CHOREONOID_BODY_LIBRARIES_ABS ${CHOREONOID_BODY_LIBRARIES_ABS} ${${lib}_abs})
 endforeach(lib)
+message ("cnoid_body_lib: ${CHOREONOID_BODY_LIBRARIES_ABS}")
 
 add_library(${PROJECT_NAME}
   src/FullbodyInverseKinematicsSolverFast.cpp
@@ -156,6 +162,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 #############
 
 add_subdirectory(sample)
+add_subdirectory(python)
 
 ## Add gtest based cpp test target and link libraries
 # catkin_add_gtest(${PROJECT_NAME}-test test/test_fullbody_inverse_kinematics_solver.cpp)

--- a/fullbody_inverse_kinematics_solver/python/CMakeLists.txt
+++ b/fullbody_inverse_kinematics_solver/python/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(TARGET PyFullbodyIK)
+
+add_cnoid_python_module(${TARGET} PyFullbodyIKModule.cpp)
+
+target_link_libraries(${TARGET}
+  ${catkin_LIBRARIES}
+  ${CHOREONOID_BODY_LIBRARIES_ABS}
+  ${PROJECT_NAME}
+  )
+
+target_compile_definitions(${TARGET} PUBLIC ${CHOREONOID_COMPILE_DEFINITIONS})
+
+set(choreonoid_PYTHON_DIR ${CHOREONOID_ROOT_DIR}/${CHOREONOID_PYTHON_SUBDIR}/cnoid)## copy from jsk_choreonoid
+set_target_properties(${TARGET}
+  PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${choreonoid_PYTHON_DIR})# copy the library for calling 'import cnoid.hoge'

--- a/fullbody_inverse_kinematics_solver/python/PyFullbodyIKModule.cpp
+++ b/fullbody_inverse_kinematics_solver/python/PyFullbodyIKModule.cpp
@@ -43,6 +43,9 @@ typedef std::shared_ptr<IK::JointLimitConstraint >      JointLimitConstraintPtr;
 typedef std::shared_ptr<IK::JointVelocityConstraint >   JointVelocityConstraintPtr;
 typedef std::shared_ptr<IK::PositionConstraint >        PositionConstraintPtr;
 
+using Matrix4RM = Eigen::Matrix<double, 4, 4, Eigen::RowMajor>;
+using Matrix3RM = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
+
 class Constraints
 {
 public:
@@ -137,6 +140,15 @@ PYBIND11_MODULE(FullbodyIK, m)
       .def_property("eval_R",
                     (cnoid::Matrix3d & (IK::COMConstraint::*)()) &IK::COMConstraint::eval_R,
                     &IK::COMConstraint::set_eval_R)
+      .def_property("maxError",
+                    (cnoid::Vector3 & (IK::COMConstraint::*)()) &IK::COMConstraint::maxError,
+                    &IK::COMConstraint::set_maxError)
+      .def_property("precision",
+                    (cnoid::Vector3 & (IK::COMConstraint::*)()) &IK::COMConstraint::precision,
+                    &IK::COMConstraint::set_precision)
+      .def_property("weight",
+                    (cnoid::Vector3 & (IK::COMConstraint::*)()) &IK::COMConstraint::weight,
+                    &IK::COMConstraint::set_weight)
       ;
 
     py::class_<IK::COMVelocityConstraint, COMVelocityConstraintPtr, IK::IKConstraint > (m, "COMVelocityConstraint")
@@ -184,11 +196,17 @@ PYBIND11_MODULE(FullbodyIK, m)
                     (cnoid::LinkPtr & (IK::PositionConstraint::*)()) &IK::PositionConstraint::eval_link,
                     &IK::PositionConstraint::set_eval_link)
       .def_property("A_localpos",
-                    (cnoid::Position & (IK::PositionConstraint::*)()) &IK::PositionConstraint::A_localpos,
-                    &IK::PositionConstraint::set_A_localpos)
+                    //(cnoid::Position & (IK::PositionConstraint::*)()) &IK::PositionConstraint::A_localpos,
+                    //&IK::PositionConstraint::set_A_localpos)
+                    [](IK::PositionConstraint& self) -> Isometry3::MatrixType& { return self.A_localpos().matrix(); },
+                    [](IK::PositionConstraint& self, Eigen::Ref<const Matrix4RM> in_pos) {
+                      Position p(in_pos); self.set_A_localpos(p); })
       .def_property("B_localpos",
-                    (cnoid::Position & (IK::PositionConstraint::*)()) &IK::PositionConstraint::B_localpos,
-                    &IK::PositionConstraint::set_B_localpos)
+                    //(cnoid::Position & (IK::PositionConstraint::*)()) &IK::PositionConstraint::B_localpos,
+                    //&IK::PositionConstraint::set_B_localpos)
+                    [](IK::PositionConstraint& self) -> Isometry3::MatrixType& { return self.B_localpos().matrix(); },
+                    [](IK::PositionConstraint& self, Eigen::Ref<const Matrix4RM> in_pos) {
+                      Position p(in_pos); self.set_B_localpos(p); })
       .def_property("maxError",
                     (cnoid::Vector6 & (IK::PositionConstraint::*)()) &IK::PositionConstraint::maxError,
                     &IK::PositionConstraint::set_maxError)

--- a/fullbody_inverse_kinematics_solver/python/PyFullbodyIKModule.cpp
+++ b/fullbody_inverse_kinematics_solver/python/PyFullbodyIKModule.cpp
@@ -1,0 +1,246 @@
+/**
+   @author YoheiKakiuchi
+*/
+
+#include <cnoid/PyUtil>
+// #include "../BodyUtil.h"
+#include "fullbody_inverse_kinematics_solver/FullbodyInverseKinematicsSolverFast.h"
+
+#include <ik_constraint/AngularMomentumConstraint.h>
+#include <ik_constraint/COMConstraint.h>
+#include <ik_constraint/COMVelocityConstraint.h>
+#include <ik_constraint/ClientCollisionConstraint.h>
+//#include <ik_constraint/CollisionConstraint.h>
+#include <ik_constraint/JointAngleConstraint.h>
+#include <ik_constraint/JointLimitConstraint.h>
+#include <ik_constraint/JointVelocityConstraint.h>
+#include <ik_constraint/PositionConstraint.h>
+#include <ik_constraint/IKConstraint.h>
+
+#include <memory>
+#include <pybind11/pybind11.h>
+
+using namespace cnoid;
+namespace py = pybind11;
+
+//IKConstraint
+//COM
+//COMVelocity
+//ClientCollision
+//JointAngle
+//JointLimit
+//JointVelocity
+//Position
+
+class Constraints
+{
+public:
+  std::vector< std::shared_ptr <IK::IKConstraint > > ikc_list;
+
+public:
+  Constraints() { };
+
+public:
+  void push_back(std::shared_ptr <IK::IKConstraint > &ptr) {
+    ikc_list.push_back(ptr);
+  }
+  void push_back(std::shared_ptr <IK::COMConstraint > &ptr) {
+    ikc_list.push_back(ptr);
+  }
+  void push_back(std::shared_ptr <IK::COMVelocityConstraint > &ptr) {
+    ikc_list.push_back(ptr);
+  }
+  void push_back(std::shared_ptr <IK::ClientCollisionConstraint > &ptr) {
+    ikc_list.push_back(ptr);
+  }
+  void push_back(std::shared_ptr <IK::JointAngleConstraint > &ptr) {
+    ikc_list.push_back(ptr);
+  }
+  void push_back(std::shared_ptr <IK::JointLimitConstraint > &ptr) {
+    ikc_list.push_back(ptr);
+  }
+  void push_back(std::shared_ptr <IK::JointVelocityConstraint > &ptr) {
+    ikc_list.push_back(ptr);
+  }
+  void push_back(std::shared_ptr <IK::PositionConstraint > &ptr) {
+    ikc_list.push_back(ptr);
+  }
+  size_t size() { return ikc_list.size(); }
+};
+
+int solveFullbodyIKLoopFast (const cnoid::BodyPtr& robot,
+                             //const std::vector<std::shared_ptr<IK::IKConstraint> >& ikc_list,
+                             Constraints &const_,
+                             cnoid::VectorX& jlim_avoid_weight_old,
+                             const cnoid::VectorX& dq_weight_all,
+                             const size_t max_iteration,
+                             double wn,
+                             int debugLevel)
+                             //const size_t max_iteration = 1,
+                             //double wn = 1e-6,
+                             //int debugLevel = 0)
+{
+  return fik::solveFullbodyIKLoopFast(robot,
+                                      const_.ikc_list,
+                                      jlim_avoid_weight_old,
+                                      dq_weight_all,
+                                      max_iteration,
+                                      wn,
+                                      debugLevel);
+}
+
+#if 0
+class pyIKConstraint : public IK::IKConstraint
+{
+public:
+  using IK::IKConstraint::IKConstraint;
+
+  // trampoline (one for each virtual function)
+  virtual bool checkConvergence () override {
+    PYBIND11_OVERLOAD_PURE(
+      bool, /* Return type */
+      IK::IKConstraint,      /* Parent class */
+      checkConvergence        /* Name of function in C++ (must match Python name) */
+    );
+  }
+};
+#endif
+
+PYBIND11_MODULE(FullbodyIK, m)
+{
+    m.doc() = "fullbody inverse kinematics module";
+
+    py::module::import("cnoid.Util");
+
+#if 0
+    py::class_< IK::IKConstraint, pyIKConstraint > (m, "IKConstraint")
+      .def(py::init<>())
+      .def("checkConvergence", &IK::IKConstraint::checkConvergence);
+#endif
+
+    py::class_< Constraints > (m, "Constraints")
+      .def(py::init<>())
+      .def("size", &Constraints::size)
+      .def("__iter__", [](const Constraints &s) { return py::make_iterator(s.ikc_list.begin(), s.ikc_list.end()); },
+           py::keep_alive<0, 1>())
+      .def("push_back", (void (Constraints::*)(std::shared_ptr< IK::COMConstraint> &)) &Constraints::push_back)
+      .def("push_back", (void (Constraints::*)(std::shared_ptr< IK::COMVelocityConstraint> &)) &Constraints::push_back)
+      .def("push_back", (void (Constraints::*)(std::shared_ptr< IK::ClientCollisionConstraint> &)) &Constraints::push_back)
+      .def("push_back", (void (Constraints::*)(std::shared_ptr< IK::JointAngleConstraint> &)) &Constraints::push_back)
+      .def("push_back", (void (Constraints::*)(std::shared_ptr< IK::JointLimitConstraint> &)) &Constraints::push_back)
+      .def("push_back", (void (Constraints::*)(std::shared_ptr< IK::JointVelocityConstraint> &)) &Constraints::push_back)
+      .def("push_back", (void (Constraints::*)(std::shared_ptr< IK::PositionConstraint> &)) &Constraints::push_back)
+      ;
+
+    py::class_<IK::AngularMomentumConstraint, std::shared_ptr< IK::AngularMomentumConstraint> > (m, "AngularMomentumConstraint")
+      .def(py::init<>());
+
+    py::class_<IK::COMConstraint, std::shared_ptr< IK::COMConstraint> > (m, "COMConstraint")
+      .def(py::init<>())
+      .def("checkConvergence", &IK::COMConstraint::checkConvergence)
+      .def_property("debuglevel", (int & (IK::IKConstraint::*)())&IK::IKConstraint::debuglevel, &IK::IKConstraint::set_debuglevel)
+      .def_property("A_robot",
+                    (cnoid::BodyPtr & (IK::COMConstraint::*)()) &IK::COMConstraint::A_robot,
+                    &IK::COMConstraint::set_A_robot)
+      .def_property("B_robot",
+                    (cnoid::BodyPtr & (IK::COMConstraint::*)()) &IK::COMConstraint::B_robot,
+                    &IK::COMConstraint::set_B_robot)
+      .def_property("A_localp",
+                    (cnoid::Vector3 & (IK::COMConstraint::*)()) &IK::COMConstraint::A_localp,
+                    &IK::COMConstraint::set_A_localp)
+      .def_property("B_localp",
+                    (cnoid::Vector3 & (IK::COMConstraint::*)()) &IK::COMConstraint::B_localp,
+                    &IK::COMConstraint::set_B_localp)
+      .def_property("eval_R",
+                    (cnoid::Matrix3d & (IK::COMConstraint::*)()) &IK::COMConstraint::eval_R,
+                    &IK::COMConstraint::set_eval_R)
+      ;
+
+    py::class_<IK::COMVelocityConstraint, std::shared_ptr< IK::COMVelocityConstraint> > (m, "COMVelocityConstraint")
+      .def(py::init<>())
+      .def_property("debuglevel", (int & (IK::IKConstraint::*)())&IK::IKConstraint::debuglevel, &IK::IKConstraint::set_debuglevel)
+      .def("checkConvergence", &IK::COMVelocityConstraint::checkConvergence)
+      ;
+
+    py::class_<IK::ClientCollisionConstraint, std::shared_ptr< IK::ClientCollisionConstraint> > (m, "ClientCollisionConstraint")
+      .def(py::init<>())
+      .def_property("debuglevel", (int & (IK::IKConstraint::*)())&IK::IKConstraint::debuglevel, &IK::IKConstraint::set_debuglevel)
+      .def("checkConvergence", &IK::ClientCollisionConstraint::checkConvergence)
+      ;
+    //py::class_<IK::CollisionConstraint, std::shared_ptr< IK::CollisionConstraint> > (m, "CollisionConstraint")
+    //  .def(py::init<>());
+    py::class_<IK::JointAngleConstraint, std::shared_ptr< IK::JointAngleConstraint> > (m, "JointAngleConstraint")
+      .def(py::init<>())
+      .def_property("debuglevel", (int & (IK::IKConstraint::*)())&IK::IKConstraint::debuglevel, &IK::IKConstraint::set_debuglevel)
+      .def("checkConvergence", &IK::JointAngleConstraint::checkConvergence)
+      .def_property("joint",
+                    (cnoid::LinkPtr & (IK::JointAngleConstraint::*)()) &IK::JointAngleConstraint::joint,
+                    &IK::JointAngleConstraint::set_joint)
+      .def_property("targetq",
+                    (double & (IK::JointAngleConstraint::*)()) &IK::JointAngleConstraint::targetq,
+                    &IK::JointAngleConstraint::set_targetq)
+      .def_property("maxError",
+                    (double & (IK::JointAngleConstraint::*)()) &IK::JointAngleConstraint::maxError,
+                    &IK::JointAngleConstraint::set_maxError)
+      .def_property("precision",
+                    (double & (IK::JointAngleConstraint::*)()) &IK::JointAngleConstraint::precision,
+                    &IK::JointAngleConstraint::set_precision)
+      .def_property("weight",
+                    (double & (IK::JointAngleConstraint::*)()) &IK::JointAngleConstraint::weight,
+                    &IK::JointAngleConstraint::set_weight)
+      ;
+
+    py::class_<IK::JointLimitConstraint, std::shared_ptr< IK::JointLimitConstraint> > (m, "JointLimitConstraint")
+      .def(py::init<>())
+      .def("checkConvergence", &IK::JointLimitConstraint::checkConvergence)
+      .def_property("debuglevel", (int & (IK::IKConstraint::*)())&IK::IKConstraint::debuglevel, &IK::IKConstraint::set_debuglevel)
+      ;
+    py::class_<IK::JointVelocityConstraint, std::shared_ptr< IK::JointVelocityConstraint> > (m, "JointVelocityConstraint")
+      .def("checkConvergence", &IK::JointVelocityConstraint::checkConvergence)
+      .def_property("debuglevel", (int & (IK::IKConstraint::*)())&IK::IKConstraint::debuglevel, &IK::IKConstraint::set_debuglevel)
+      .def(py::init<>())
+      ;
+
+    py::class_<IK::PositionConstraint, std::shared_ptr< IK::PositionConstraint> > (m, "PositionConstraint")
+      .def(py::init<>())
+      .def("checkConvergence", &IK::PositionConstraint::checkConvergence)
+      .def_property("debuglevel", (int & (IK::IKConstraint::*)())&IK::IKConstraint::debuglevel, &IK::IKConstraint::set_debuglevel)
+      .def_property("A_link",
+                    (cnoid::LinkPtr & (IK::PositionConstraint::*)()) &IK::PositionConstraint::A_link,
+                    &IK::PositionConstraint::set_A_link)
+      .def_property("B_link",
+                    (cnoid::LinkPtr & (IK::PositionConstraint::*)()) &IK::PositionConstraint::B_link,
+                    &IK::PositionConstraint::set_B_link)
+      .def_property("eval_link",
+                    (cnoid::LinkPtr & (IK::PositionConstraint::*)()) &IK::PositionConstraint::eval_link,
+                    &IK::PositionConstraint::set_eval_link)
+      .def_property("A_localpos",
+                    (cnoid::Position & (IK::PositionConstraint::*)()) &IK::PositionConstraint::A_localpos,
+                    &IK::PositionConstraint::set_A_localpos)
+      .def_property("B_localpos",
+                    (cnoid::Position & (IK::PositionConstraint::*)()) &IK::PositionConstraint::B_localpos,
+                    &IK::PositionConstraint::set_B_localpos)
+      .def_property("maxError",
+                    (cnoid::Vector6 & (IK::PositionConstraint::*)()) &IK::PositionConstraint::maxError,
+                    &IK::PositionConstraint::set_maxError)
+      .def_property("precision",
+                    (cnoid::Vector6 & (IK::PositionConstraint::*)()) &IK::PositionConstraint::precision,
+                    &IK::PositionConstraint::set_precision)
+      .def_property("weight",
+                    (cnoid::Vector6 & (IK::PositionConstraint::*)()) &IK::PositionConstraint::weight,
+                    &IK::PositionConstraint::set_weight)
+      .def_property("eval_localR",
+                    (cnoid::Matrix3d & (IK::PositionConstraint::*)()) &IK::PositionConstraint::eval_localR,
+                    &IK::PositionConstraint::set_eval_localR)
+      ;
+
+
+    m.def("solveFullbodyIKLoopFast", &solveFullbodyIKLoopFast,
+          py::arg("robot"),
+          py::arg("const"),
+          py::arg("jlim_avoid_weight_old"),
+          py::arg("dq_weight_all"),
+          py::arg("max_iteration") = 1,
+          py::arg("double wn") = 1e-6,
+          py::arg("int debugLevel") = 0);
+}

--- a/fullbody_inverse_kinematics_solver/sample/CMakeLists.txt
+++ b/fullbody_inverse_kinematics_solver/sample/CMakeLists.txt
@@ -2,10 +2,10 @@ add_compile_options(-std=c++11)
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
 find_package(catkin REQUIRED COMPONENTS
-  ik_constraint
+  #ik_constraint
   roslib
   )
-find_package(choreonoid REQUIRED)
+#find_package(choreonoid REQUIRED)
 
 include_directories(
   include
@@ -13,15 +13,15 @@ include_directories(
   ${CHOREONOID_INCLUDE_DIRS}
 )
 
-# 相対パスを絶対パスに直す
-set(CHOREONOID_BODY_LIBRARIES_ABS)
-foreach(lib ${CHOREONOID_BODY_LIBRARIES})
-  find_library(${lib}_abs NAMES ${lib} PATHS ${CHOREONOID_LIBRARY_DIRS})
-  if (NOT (${lib}_abs))
-    set(${lib}_abs ${lib})
-  endif()
-  set(CHOREONOID_BODY_LIBRARIES_ABS ${CHOREONOID_BODY_LIBRARIES_ABS} ${${lib}_abs})
-endforeach(lib)
+### 相対パスを絶対パスに直す
+##set(CHOREONOID_BODY_LIBRARIES_ABS)
+##foreach(lib ${CHOREONOID_BODY_LIBRARIES})
+##  find_library(${lib}_abs NAMES ${lib} PATHS ${CHOREONOID_LIBRARY_DIRS})
+##  if (NOT (${lib}_abs))
+##    set(${lib}_abs ${lib})
+##  endif()
+##  set(CHOREONOID_BODY_LIBRARIES_ABS ${CHOREONOID_BODY_LIBRARIES_ABS} ${${lib}_abs})
+##endforeach(lib)
 
 add_executable(sampleSR1
   SampleSR1.cpp
@@ -29,7 +29,7 @@ add_executable(sampleSR1
 
 target_link_libraries(sampleSR1
   ${catkin_LIBRARIES}
-  ${CHOREONOID_BODY_LIBRARIES_ABS}
+  ${CHOREONOID_BODY_LIBRARIES}
   ${PROJECT_NAME}
   )
 

--- a/fullbody_inverse_kinematics_solver/sample/CMakeLists.txt
+++ b/fullbody_inverse_kinematics_solver/sample/CMakeLists.txt
@@ -17,6 +17,9 @@ include_directories(
 set(CHOREONOID_BODY_LIBRARIES_ABS)
 foreach(lib ${CHOREONOID_BODY_LIBRARIES})
   find_library(${lib}_abs NAMES ${lib} PATHS ${CHOREONOID_LIBRARY_DIRS})
+  if (NOT (${lib}_abs))
+    set(${lib}_abs ${lib})
+  endif()
   set(CHOREONOID_BODY_LIBRARIES_ABS ${CHOREONOID_BODY_LIBRARIES_ABS} ${${lib}_abs})
 endforeach(lib)
 

--- a/fullbody_inverse_kinematics_solver/sample/cnoid_pyutil.py
+++ b/fullbody_inverse_kinematics_solver/sample/cnoid_pyutil.py
@@ -86,5 +86,6 @@ def findRobot(name):
 
 def flushRobotView(name):
     findItem(name).notifyKinematicStateChange()
-    MessageView.getInstance().flush()
+    #MessageView.getInstance().flush()
+    MessageView.instance.flush()
 

--- a/fullbody_inverse_kinematics_solver/sample/cnoid_pyutil.py
+++ b/fullbody_inverse_kinematics_solver/sample/cnoid_pyutil.py
@@ -1,0 +1,90 @@
+from cnoid.Base import *
+from cnoid.BodyPlugin import *
+#from cnoid.PythonSimScriptPlugin import *
+import cnoid.Body
+
+import numpy as np
+
+def getItemTreeView():
+    if callable(ItemTreeView.instance):
+        return ItemTreeView.instance()
+    else:
+        return ItemTreeView.instance
+
+
+def getRootItem():
+    if callable(RootItem.instance):
+        return RootItem.instance()
+    else:
+        return RootItem.instance
+
+
+def getWorld():
+    rI = getRootItem()
+    ret = rI.findItem("World")
+    if ret == None:
+        ret = WorldItem()
+        rI.addChildItem(ret)
+        getItemTreeView().checkItem(ret)
+    return ret
+
+
+def cnoidPosition(rotation = None, translation = None):
+  ret = np.identity(4)
+  if not (rotation is None):
+    ret[:3, :3] = rotation
+  if not (translation is None):
+    ret[:3, 3] = translation
+  return ret
+
+
+def cnoidRotation(cPosition):
+  return cPosition[:3, :3]
+
+
+def cnoidTranslation(cPosition):
+  return cPosition[:3, 3]
+
+
+def loadRobot(fname, name = None):
+    print('loadRobot: %s'%(fname))
+    bI = BodyItem()
+    bI.load(fname)
+    if name:
+        bI.setName(name)
+    if callable(bI.body):
+        rr = bI.body()
+    else:
+        rr = bI.body
+    rr.calcForwardKinematics()
+    bI.storeInitialState()
+    wd = getWorld()
+    if callable(wd.childItem):
+        wd.insertChildItem(bI, wd.childItem())
+    else:
+        wd.insertChildItem(bI, wd.childItem)
+    getItemTreeView().checkItem(bI)
+    return rr
+
+
+#def loadRobot(fname, name = None):
+#    print('loadRobot: %s'%(fname))
+#    import time
+#    time.sleep(0.5)
+#    return fname
+
+def findItem(name):
+    return getRootItem().findItem(name)
+
+def findRobot(name):
+    ret = findItem(name)
+    ## add class check...
+    if callable(ret.body):
+        return ret.body()
+    else:
+        return ret.body
+
+def flushRobotView(name):
+    findItem(name).notifyKinematicStateChange()
+    MessageView.getInstance().flush()
+

--- a/fullbody_inverse_kinematics_solver/sample/sample.py
+++ b/fullbody_inverse_kinematics_solver/sample/sample.py
@@ -30,7 +30,8 @@ constraint = FullbodyIK.PositionConstraint()
 constraint.A_link = robot.link('RARM_WRIST_R');
 constraint.A_localpos = cnoidPosition(translation=np.array([0.0, 0.0, -0.02]))
 #constraint.B_link() = nullptr;
-constraint.B_localpos = cnoidPosition(translation=np.array([0.3, -0.2, 0.8]))
+constraint.B_localpos = cnoidPosition(translation=np.array([0.3, -0.2, 0.8]), rotation=cnoid.Util.angleAxis(-1.5, np.array([0,1,0])))
+#cnoid.Util.AngleAxis(-1.5, np.array([0,1,0])).toRotationMatrix()
 ## constraint.B_localpos().linear() = cnoid::Matrix3(cnoid::AngleAxis(-1.5,cnoid::Vector3(0,1,0)));
 constraints.push_back(constraint)
 
@@ -39,7 +40,7 @@ constraint = FullbodyIK.PositionConstraint()
 constraint.A_link = robot.link('LARM_WRIST_R')
 constraint.A_localpos = cnoidPosition(translation=np.array([0.0, 0.0,-0.02]))
 #constraint->B_link() = nullptr;
-constraint.B_localpos = cnoidPosition(translation=np.array([0.3, 0.2, 0.8]))
+constraint.B_localpos = cnoidPosition(translation=np.array([0.3, 0.2, 0.8]), rotation=cnoid.Util.angleAxis(-1.5, np.array([0,1,0])))
 #constraint->B_localpos().linear() = cnoid::Matrix3(cnoid::AngleAxis(-1.5,cnoid::Vector3(0,1,0)));
 weight = constraint.weight
 for idx in range(3):

--- a/fullbody_inverse_kinematics_solver/sample/sample.py
+++ b/fullbody_inverse_kinematics_solver/sample/sample.py
@@ -1,0 +1,106 @@
+## aim to do the same procedure as SampleSR1.cpp
+## exec(open('sample.py').read())
+
+import cnoid.Util
+from cnoid_pyutil import *
+from cnoid import FullbodyIK
+import numpy as np
+
+fname = cnoid.Util.getShareDirectory() + '/model/SR1/SR1.body'
+robot = loadRobot(fname)
+
+reset_pose_av = np.array([ 0.0, -0.349066, 0.0, 0.820305, -0.471239, 0.0, ## rleg
+                           0.523599, 0.0, 0.0, -1.74533, 0.15708, -0.113446, 0.637045, ## rarm
+                           0.0, -0.349066, 0.0, 0.820305, -0.471239, 0.0, ## lleg
+                           0.523599, 0.0, 0.0, -1.74533, -0.15708, -0.113446, -0.637045, ## larm
+                           0.0, 0.0, 0.0 ]);
+
+for idx in range(len(reset_pose_av)):
+    robot.joint(idx).q = reset_pose_av[idx]
+
+robot.calcForwardKinematics()
+robot.calcCenterOfMass()
+
+flushRobotView('SR1')
+
+constraints = FullbodyIK.Constraints()
+
+## task: rarm to target
+constraint = FullbodyIK.PositionConstraint()
+constraint.A_link = robot.link('RARM_WRIST_R');
+constraint.A_localpos = cnoidPosition(translation=np.array([0.0, 0.0, -0.02]))
+#constraint.B_link() = nullptr;
+constraint.B_localpos = cnoidPosition(translation=np.array([0.3, -0.2, 0.8]))
+## constraint.B_localpos().linear() = cnoid::Matrix3(cnoid::AngleAxis(-1.5,cnoid::Vector3(0,1,0)));
+constraints.push_back(constraint)
+
+## task: larm to target. rotation-axis nil
+constraint = FullbodyIK.PositionConstraint()
+constraint.A_link = robot.link('LARM_WRIST_R')
+constraint.A_localpos = cnoidPosition(translation=np.array([0.0, 0.0,-0.02]))
+#constraint->B_link() = nullptr;
+constraint.B_localpos = cnoidPosition(translation=np.array([0.3, 0.2, 0.8]))
+#constraint->B_localpos().linear() = cnoid::Matrix3(cnoid::AngleAxis(-1.5,cnoid::Vector3(0,1,0)));
+weight = constraint.weight
+for idx in range(3):
+    weight[idx+3] = 0.0
+
+constraint.weight = weight ## not require??
+constraints.push_back(constraint)
+
+## task: rleg to target
+constraint = FullbodyIK.PositionConstraint()
+constraint.A_link = robot.link('RLEG_ANKLE_R')
+constraint.A_localpos = cnoidPosition(translation=np.array([0.0, 0.0, -0.04]))
+#constraint->B_link() = nullptr;
+constraint.B_localpos = cnoidPosition(translation=np.array([0.0, -0.2, 0.0]))
+constraints.push_back(constraint)
+
+## task: lleg to target
+constraint = FullbodyIK.PositionConstraint()
+constraint.A_link = robot.link('LLEG_ANKLE_R')
+constraint.A_localpos = cnoidPosition(translation=np.array([0.0, 0.0, -0.04]))
+#constraint->B_link() = nullptr;
+constraint.B_localpos = cnoidPosition(translation=np.array([0.0, 0.2, 0.0]))
+constraints.push_back(constraint)
+
+## task: COM to target
+constraint = FullbodyIK.COMConstraint()
+constraint.A_robot = robot
+constraint.B_localp = np.array([0.0, 0.0, 0.7])
+constraints.push_back(constraint)
+
+
+## task: joint angle to target
+constraint = FullbodyIK.JointAngleConstraint()
+constraint.joint = robot.link('CHEST')
+constraint.targetq = 0.1
+constraints.push_back(constraint)
+
+
+for const in constraints:
+    const.debuglevel = 1
+
+
+jlim_avoid_weight_old = np.zeros(6 + robot.getNumJoints())
+dq_weight_all = np.ones(6 + robot.getNumJoints())
+
+loop = FullbodyIK.solveFullbodyIKLoopFast(robot,
+                                          constraints,
+                                          jlim_avoid_weight_old,
+                                          dq_weight_all,
+                                          20,
+                                          1e-6,
+                                          1)
+
+flushRobotView('SR1')
+
+cntr = 0
+for const in constraints:
+    const.debuglevel = 1
+    if const.checkConvergence():
+        print('constraint %d (%s) : converged'%(cntr, const))
+    else:
+        print('constraint %d (%s) : NOT converged'%(cntr, const))
+    cntr = cntr + 1
+

--- a/ik_constraint/CMakeLists.txt
+++ b/ik_constraint/CMakeLists.txt
@@ -28,16 +28,16 @@ include_directories(
   ${CHOREONOID_INCLUDE_DIRS}
 )
 
-# 相対パスを絶対パスに直す
-set(CHOREONOID_BODY_LIBRARIES_ABS)
-foreach(lib ${CHOREONOID_BODY_LIBRARIES})
-  find_library(${lib}_abs NAMES ${lib} PATHS ${CHOREONOID_LIBRARY_DIRS})
-  if (NOT (${lib}_abs))
-    set(${lib}_abs ${lib})
-  endif()
-  set(CHOREONOID_BODY_LIBRARIES_ABS ${CHOREONOID_BODY_LIBRARIES_ABS} ${${lib}_abs})
-endforeach(lib)
-message ("cnoid_body_lib: ${CHOREONOID_BODY_LIBRARIES_ABS}")
+### 相対パスを絶対パスに直す
+##set(CHOREONOID_BODY_LIBRARIES_ABS)
+##foreach(lib ${CHOREONOID_BODY_LIBRARIES})
+##  find_library(${lib}_abs NAMES ${lib} PATHS ${CHOREONOID_LIBRARY_DIRS})
+##  if (NOT (${lib}_abs))
+##    set(${lib}_abs ${lib})
+##  endif()
+##  set(CHOREONOID_BODY_LIBRARIES_ABS ${CHOREONOID_BODY_LIBRARIES_ABS} ${${lib}_abs})
+##endforeach(lib)
+##message ("cnoid_body_lib: ${CHOREONOID_BODY_LIBRARIES_ABS}")
 
 add_library(${PROJECT_NAME}
   src/Jacobian.cpp
@@ -55,7 +55,7 @@ add_library(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
-  ${CHOREONOID_BODY_LIBRARIES_ABS}
+  ${CHOREONOID_BODY_LIBRARIES}
   )
 
 #############

--- a/ik_constraint/CMakeLists.txt
+++ b/ik_constraint/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
+cmake_policy(SET CMP0003 NEW)
+cmake_policy(SET CMP0057 NEW)
+
 project(ik_constraint)
 
 add_compile_options(-std=c++11)
@@ -29,8 +32,12 @@ include_directories(
 set(CHOREONOID_BODY_LIBRARIES_ABS)
 foreach(lib ${CHOREONOID_BODY_LIBRARIES})
   find_library(${lib}_abs NAMES ${lib} PATHS ${CHOREONOID_LIBRARY_DIRS})
+  if (NOT (${lib}_abs))
+    set(${lib}_abs ${lib})
+  endif()
   set(CHOREONOID_BODY_LIBRARIES_ABS ${CHOREONOID_BODY_LIBRARIES_ABS} ${${lib}_abs})
 endforeach(lib)
+message ("cnoid_body_lib: ${CHOREONOID_BODY_LIBRARIES_ABS}")
 
 add_library(${PROJECT_NAME}
   src/Jacobian.cpp

--- a/ik_constraint/include/ik_constraint/COMConstraint.h
+++ b/ik_constraint/include/ik_constraint/COMConstraint.h
@@ -19,6 +19,7 @@ namespace IK{
     //  precision: 収束判定の閾値
     //  weight: コスト関数の重み. error * weight^2 * error. 0の成分はjacobianやerrorに含まれない
     //状態が更新される度に, 手動でcalcForwardKinematics()とcalcCenterOfMass()を呼ぶ必要が有る.
+#if 0
     const cnoid::BodyPtr& A_robot() const { return A_robot_;}
     cnoid::BodyPtr& A_robot() { return A_robot_;}
     const cnoid::Vector3& A_localp() const { return A_localp_;}
@@ -29,7 +30,18 @@ namespace IK{
     cnoid::Vector3& B_localp() { return B_localp_;}
     const cnoid::Matrix3d& eval_R() const { return eval_R_;}
     cnoid::Matrix3d& eval_R() { return eval_R_;}
+#else
+#define define_setter_getter(type,nm)                           \
+    void set_ ## nm (const type &in_arg) { nm ## _ = in_arg; }  \
+    const type  & nm () const { return nm ## _; }               \
+    type  & nm () { return nm ## _; }
 
+    define_setter_getter(cnoid::BodyPtr,A_robot);
+    define_setter_getter(cnoid::Vector3,A_localp);
+    define_setter_getter(cnoid::BodyPtr,B_robot);
+    define_setter_getter(cnoid::Vector3,B_localp);
+    define_setter_getter(cnoid::Matrix3d,eval_R);
+#endif
     // for equality
     const cnoid::Vector3& maxError() const { return maxError_;}
     cnoid::Vector3& maxError() { return maxError_;}

--- a/ik_constraint/include/ik_constraint/COMConstraint.h
+++ b/ik_constraint/include/ik_constraint/COMConstraint.h
@@ -41,7 +41,14 @@ namespace IK{
     define_setter_getter(cnoid::BodyPtr,B_robot);
     define_setter_getter(cnoid::Vector3,B_localp);
     define_setter_getter(cnoid::Matrix3d,eval_R);
+
+    // for equality
+    define_setter_getter(cnoid::Vector3,maxError);
+    define_setter_getter(cnoid::Vector3,precision);
+    define_setter_getter(cnoid::Vector3,weight);
 #endif
+
+#if 0
     // for equality
     const cnoid::Vector3& maxError() const { return maxError_;}
     cnoid::Vector3& maxError() { return maxError_;}
@@ -49,7 +56,7 @@ namespace IK{
     cnoid::Vector3& precision() { return precision_;}
     const cnoid::Vector3& weight() const { return weight_;}
     cnoid::Vector3& weight() { return weight_;}
-
+#endif
     // for inequality
     const Eigen::SparseMatrix<double,Eigen::RowMajor>& C() const { return C_;}
     Eigen::SparseMatrix<double,Eigen::RowMajor>& C() { return C_;}

--- a/ik_constraint/include/ik_constraint/IKConstraint.h
+++ b/ik_constraint/include/ik_constraint/IKConstraint.h
@@ -35,6 +35,7 @@ namespace IK{
 
     const int& debuglevel() const { return debuglevel_;}
     int& debuglevel() { return debuglevel_;}
+    void set_debuglevel (int &in) { debuglevel_ = in; }
 
     static size_t getJointDOF(const cnoid::LinkPtr& joint);
   protected:

--- a/ik_constraint/include/ik_constraint/JointAngleConstraint.h
+++ b/ik_constraint/include/ik_constraint/JointAngleConstraint.h
@@ -12,7 +12,7 @@ namespace IK{
     //  maxError: エラーの頭打ち
     //  precision: 収束判定の閾値
     //  weight: コスト関数の重み. error * weight^2 * error.
-
+#if 0
     const cnoid::LinkPtr& joint() const { return joint_;}
     cnoid::LinkPtr& joint() { return joint_;}
     const double& targetq() const { return targetq_;}
@@ -23,7 +23,18 @@ namespace IK{
     double& precision() { return precision_;}
     const double& weight() const { return weight_;}
     double& weight() { return weight_;}
+#else
+#define define_setter_getter(type,nm)                           \
+    void set_ ## nm (const type &in_arg) { nm ## _ = in_arg; }  \
+    const type  & nm () const { return nm ## _; }               \
+    type  & nm () { return nm ## _; }
 
+    define_setter_getter(cnoid::LinkPtr,joint);
+    define_setter_getter(double,targetq);
+    define_setter_getter(double,maxError);
+    define_setter_getter(double,precision);
+    define_setter_getter(double,weight);
+#endif
     bool checkConvergence () override;
     const Eigen::VectorXd& calc_error () override;
     const Eigen::SparseMatrix<double,Eigen::RowMajor>& calc_jacobian (const std::vector<cnoid::LinkPtr>& joints) override;

--- a/ik_constraint/include/ik_constraint/PositionConstraint.h
+++ b/ik_constraint/include/ik_constraint/PositionConstraint.h
@@ -18,6 +18,7 @@ namespace IK{
     //  precision: 収束判定の閾値 eval系
     //  weight: コスト関数の重み. error * weight^2 * error. 0の成分はjacobianやerrorに含まれない. eval系
     //状態が更新される度に, 手動でcalcForwardKinematics()を呼ぶ必要が有る.
+#if 0
     const cnoid::LinkPtr& A_link() const { return A_link_;}
     cnoid::LinkPtr& A_link() { return A_link_;}
     const cnoid::Position& A_localpos() const { return A_localpos_;}
@@ -36,7 +37,22 @@ namespace IK{
     cnoid::LinkPtr& eval_link() { return eval_link_;}
     const cnoid::Matrix3d& eval_localR() const { return eval_localR_;}
     cnoid::Matrix3d& eval_localR() { return eval_localR_;}
+#else
+#define define_setter_getter(type,nm)                           \
+    void set_ ## nm (const type &in_arg) { nm ## _ = in_arg; }  \
+    const type  & nm () const { return nm ## _; }               \
+    type  & nm () { return nm ## _; }
 
+    define_setter_getter(cnoid::LinkPtr,A_link);
+    define_setter_getter(cnoid::Position,A_localpos);
+    define_setter_getter(cnoid::LinkPtr,B_link);
+    define_setter_getter(cnoid::Position,B_localpos);
+    define_setter_getter(cnoid::Vector6,maxError);
+    define_setter_getter(cnoid::Vector6,precision);
+    define_setter_getter(cnoid::Vector6,weight);
+    define_setter_getter(cnoid::LinkPtr,eval_link);
+    define_setter_getter(cnoid::Matrix3d,eval_localR);
+#endif
     // 収束判定
     bool checkConvergence () override;
 


### PR DESCRIPTION

pythonから使えるようにしてみました。

fullbody_inverse_kinematics_solver/sample ディレクトリで
```
>>> exec(open('sample.py').read())
```
とすると、choreonoidにモデルがでて、IKが解けているように思います。

pybind力が低いので、IKConstraintのshared_ptrのリストを上手く渡せなかったのでwrapperを書いています。setter_getterも、もっとうまい方法はありそう。

@kindsenior 先生には話したのだけど、choreonoidをeusのように使おうと思っていて、
標準入出力からpythonコマンド入れられるようにしたものを使っています。
写真では、別ターミナルのemacsのshellからchoreonoidを使っている。

最新に近いブランチに追加したもの
https://github.com/YoheiKakiuchi/choreonoid/tree/add_console_local

release-1.7に追加したもの
https://github.com/YoheiKakiuchi/choreonoid/tree/r1.7_add_console

ref: https://github.com/kindsenior/choreonoid/pull/1

![choreonoid_console](https://user-images.githubusercontent.com/2408164/171567254-0c21746c-d362-41a6-8d5b-867b5bf53696.png)

